### PR TITLE
apache/drynx: rm cas login

### DIFF
--- a/Apache/700-demo.conf
+++ b/Apache/700-demo.conf
@@ -146,7 +146,7 @@
     CASValidateURL https://demo.c4dt.org/omniledger/api/v0/cas/serviceValidate
     CASPreserveTicket On
 
-    <Location ~ "/(drynx|stainless)">
+    <Location ~ "/stainless">
         Authtype CAS
         Require valid-user
     </Location>


### PR DESCRIPTION
Advance c4dt/TODO#210.

I'm having an issue deploying it, on `docker-compose up -d`, it fails with
```
ERROR: for traefik  Cannot create container for service traefik: Conflict. The container name "/traefik" is already in use by container "b4ba4324aede9baa15d301adeb96ec541c2e27531bc7a06ebf68a51eac7125ba". You have to remove (or rename) that container to be able to reuse that name.
ERROR: for apache  Cannot create container for service apache: Conflict. The container name "/apache" is already in use by container "07da18f5d5f01e11854648f568f18ca9497c01910ca1d90c52dfb3f25e6877d6". You have to remove (or rename) that container to be able to reuse that name.
ERROR: for socket-proxy  Cannot create container for service socket-proxy: Conflict. The container name "/socket-proxy" is already in use by container "3bbc8742ffacc0b35f0dac8faf381875bdc474c155733a6dfc489b66160390ec". You have to remove (or rename) that container to be able to reuse that name.
ERROR: for traefik  Cannot create container for service traefik: Conflict. The container name "/traefik" is already in use by container "b4ba4324aede9baa15d301adeb96ec541c2e27531bc7a06ebf68a51eac7125ba". You have to remove (or rename) that container to be able to reuse that name.
```
Note that `docker-compose ps` gives no results.

As there was some recent changes related to server management (ansible), maybe that's not the way to update it anymore? WDYT @cgrigis?